### PR TITLE
(0.5.3) Fixed submit triggered validation across multiple forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-contextual-forms",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
     "name": "react-contextual-forms",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "description": "Simple forms with React",
     "keywords": [
         "react",
-        "forms"
+        "forms",
+        "context",
+        "hooks"
     ],
     "license": "MIT",
     "author": "Sander Maas <sandermaas7@hotmail.com>",

--- a/src/common/context/FormContext.ts
+++ b/src/common/context/FormContext.ts
@@ -10,6 +10,7 @@ interface IFormContext {
 const initialState: IFormContext = {
     form: {
         fields: {},
+        isValidated: false,
         valid: true
     },
     updateFieldContext: (fieldId, field) => {},

--- a/src/common/interfaces/IForm.ts
+++ b/src/common/interfaces/IForm.ts
@@ -2,5 +2,6 @@ import { IField } from './IField'
 
 export interface IForm {
     fields: { [key: string]: IField }
+    isValidated: boolean
     valid: boolean
 }

--- a/src/components/Field.tsx
+++ b/src/components/Field.tsx
@@ -36,7 +36,9 @@ export const Field: React.FunctionComponent<IFieldProps> = ({ component, default
         if (form.fields[id] && form.fields[id].value !== value) {
             setValue(form.fields[id].value)
         }
-        if (form.fields[id] && !isTouched) setIsTouched(true)
+        if (form.isValidated && form.fields[id] && !isTouched){ 
+            setIsTouched(true)
+        }
     }, [form])
 
     const validate = () => {

--- a/src/components/Form.tsx
+++ b/src/components/Form.tsx
@@ -6,13 +6,18 @@ interface IFormProps {
     onChange?: ({}: IForm) => void
     onSubmit: ({}: IForm) => void
 }
+interface IFormSate {
+    isValidated: boolean
+}
 
-export class Form extends React.Component<IFormProps> {
+export class Form extends React.Component<IFormProps, IFormSate> {
     private _fields: {[key: string]: IField} = {}
 
     constructor(props: IFormProps) {
         super(props)
-        this.state = {}
+        this.state = {
+            isValidated: false
+        }
     }
 
     handleSubmit = (event: React.FormEvent) => {
@@ -20,14 +25,10 @@ export class Form extends React.Component<IFormProps> {
         const validForm = this.validateForm()
 
         event.preventDefault()
-        if (!validForm) {
-            this._fields = {
-                ...this._fields
-            }
-            this.forceUpdate()
-        }
+        if (!this.state.isValidated) this.setState({ isValidated: true })
         onSubmit({
             fields: this._fields,
+            isValidated: this.state.isValidated,
             valid: validForm
         })
     }
@@ -44,6 +45,7 @@ export class Form extends React.Component<IFormProps> {
         }
         if (onChange) onChange({
             fields: this._fields,
+            isValidated: this.state.isValidated,
             valid: this.validateForm()
         })
     }
@@ -61,6 +63,7 @@ export class Form extends React.Component<IFormProps> {
             }
             if (onChange) onChange({
                 fields: this._fields,
+                isValidated: this.state.isValidated,
                 valid: this.validateForm()
             })
             this.forceUpdate()   
@@ -86,6 +89,7 @@ export class Form extends React.Component<IFormProps> {
             <FormContext.Provider value={{ 
                 form: {
                     fields: this._fields,
+                    isValidated: this.state.isValidated,
                     valid: this.validateForm()
                 },
                 updateFieldContext: this.updateFieldContext,


### PR DESCRIPTION
If a component contained multiple forms and changed state or submitted one of the forms, all the forms would trigger validation. This is now solved by adding 'isValidated' (boolean) to the state of the form. Fields can now check this value to determine if validation is required or not. 